### PR TITLE
Fixes polarity of rear speakers 3/4

### DIFF
--- a/patchers/decoder/e4l.decoder.quad.maxpat
+++ b/patchers/decoder/e4l.decoder.quad.maxpat
@@ -764,7 +764,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"patching_rect" : [ 260.0, 236.0, 231.0, 22.0 ],
-					"text" : "e4l.ambidecode.angles -45. 45. 135. 225."
+					"text" : "e4l.ambidecode.angles -45. 45. -135. 135."
 				}
 
 			}


### PR DESCRIPTION
Noticed the rear speaker order is the wrong way around in the quad decoder. This should fix it.